### PR TITLE
Anchor miasma overlay to world and fix movement axes

### DIFF
--- a/src/core/input.js
+++ b/src/core/input.js
@@ -6,10 +6,11 @@ export function initInput() {
 }
 export function axis() {
   let x = 0, y = 0;
-  if (keys.has("a") || keys.has("arrowleft")) x += 1;
-  if (keys.has("d") || keys.has("arrowright")) x -= 1;
-  if (keys.has("w") || keys.has("arrowup")) y += 1;
-  if (keys.has("s") || keys.has("arrowdown")) y -= 1;
+  // Standard WASD where "A" moves left (negative X) and "D" moves right.
+  if (keys.has("a") || keys.has("arrowleft")) x -= 1;
+  if (keys.has("d") || keys.has("arrowright")) x += 1;
+  if (keys.has("w") || keys.has("arrowup")) y -= 1;
+  if (keys.has("s") || keys.has("arrowdown")) y += 1;
   const len = Math.hypot(x, y) || 1;
   return { x: x / len, y: y / len };
 }

--- a/src/render/draw.js
+++ b/src/render/draw.js
@@ -14,10 +14,9 @@ export function clear(ctx, w, h) {
 export function drawGrid(ctx, cam, w, h, cell = 64) {
   const halfW = w / 2;
   const halfH = h / 2;
-  const mod = (n, m) => ((n % m) + m) % m;
-
-  const startX = -halfW - mod(-cam.x, cell);
-  const startY = -halfH - mod(-cam.y, cell);
+  // Offset grid by camera position so it scrolls opposite to movement.
+  const startX = -halfW - (cam.x % cell);
+  const startY = -halfH - (cam.y % cell);
 
   ctx.save();
   ctx.lineWidth = 1;

--- a/src/systems/miasma/index.js
+++ b/src/systems/miasma/index.js
@@ -19,8 +19,11 @@ export function update(dt) {
 }
 
 export function draw(ctx, cam, w, h) {
-  // Lightweight overlay preview: vignette by distance to cam center.
-  const grd = ctx.createRadialGradient(w/2, h/2, 64, w/2, h/2, Math.hypot(w, h)/1.2);
+  // Lightweight overlay preview anchored to world space so it scrolls
+  // opposite to camera movement. Origin is at world (0,0).
+  const cx = w / 2 - cam.x;
+  const cy = h / 2 - cam.y;
+  const grd = ctx.createRadialGradient(cx, cy, 64, cx, cy, Math.hypot(w, h) / 1.2);
   grd.addColorStop(0, "rgba(128,0,180,0.05)");
   grd.addColorStop(1, "rgba(128,0,180,0.35)");
   ctx.fillStyle = grd;


### PR DESCRIPTION
## Summary
- Use standard WASD axis mapping so moving left/right/up/down adjusts player coordinates accordingly
- Scroll world grid based on camera offset to move opposite player input
- Anchor miasma overlay to world coordinates so it stays fixed as the player moves

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a497b842b8832d8f9af86f9d6fb964