### PR TITLE
Add shared coordinate conversion helpers

### DIFF
--- a/src/core/coords.js
+++ b/src/core/coords.js
@@ -1,0 +1,15 @@
+export function mod(n, m) {
+  return ((n % m) + m) % m;
+}
+
+export function worldToTile(wx, wy, T) {
+  return [Math.floor(wx / T), Math.floor(wy / T)];
+}
+
+export function tileToChunk(tx, ty, C) {
+  return [Math.floor(tx / C), Math.floor(ty / C)];
+}
+
+export function chunkToWorld(cx, cy, C, T) {
+  return [cx * C * T, cy * C * T];
+}

--- a/src/systems/miasma/index.js
+++ b/src/systems/miasma/index.js
@@ -1,17 +1,22 @@
 // Public surface kept tiny so internals can change freely.
+import { worldToTile } from "../../core/coords.js";
+
+const TILE_SIZE = 64; // world units per tile
 const S = { density: new Map() }; // key "x,y" -> 0..255
 
 export function init() { /* seed buffers later */ }
 
 export function sample(wx, wy) {
+  const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
   // Simple radial gradient placeholder (dense away from origin).
-  const d = Math.min(255, Math.floor(Math.hypot(wx, wy) * 0.2));
+  const d = Math.min(255, Math.floor(Math.hypot(tx, ty) * 0.2));
   return d;
 }
 
 export function clearArea(wx, wy, r, amt = 64) {
+  const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
   // Placeholder: no persistence yet; return fake cleared count.
-  return Math.max(0, Math.floor(r * amt * 0.1));
+  return Math.max(0, Math.floor((r / TILE_SIZE) * amt * 0.1));
 }
 
 export function update(dt) {

--- a/src/world/store.js
+++ b/src/world/store.js
@@ -1,5 +1,15 @@
-// Minimal world stub to start; fill in chunking later.
+// Minimal world stub to start; chunking scaffolding using shared helpers.
+import { worldToTile, tileToChunk, mod } from "../core/coords.js";
+
+const TILE_SIZE = 64; // world units per tile
+const CHUNK_SIZE = 16; // tiles per chunk
+
 export function getTile(wx, wy) {
-  // id 0 = sand, solid=false (placeholder)
+  const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
+  const [cx, cy] = tileToChunk(tx, ty, CHUNK_SIZE);
+  const lx = mod(tx, CHUNK_SIZE);
+  const ly = mod(ty, CHUNK_SIZE);
+
+  // Future: look up chunk (cx, cy) and tile (lx, ly); placeholder tile for now.
   return { id: 0, solid: false };
 }


### PR DESCRIPTION
## Summary
- add reusable coordinate helper functions for world/tile/chunk math
- use helpers in world store to scaffold chunking lookup
- convert miasma coordinates via shared helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a2e1755c832db727a315d6d3ff61