### PR TITLE
Add basic event bus and chunk enter/exit hooks

### DIFF
--- a/src/core/events.js
+++ b/src/core/events.js
@@ -1,0 +1,14 @@
+const listeners = new Map();
+
+export function on(event, handler) {
+  if (!listeners.has(event)) listeners.set(event, new Set());
+  const set = listeners.get(event);
+  set.add(handler);
+  return () => set.delete(handler);
+}
+
+export function emit(event, payload) {
+  const set = listeners.get(event);
+  if (!set) return;
+  for (const fn of [...set]) fn(payload);
+}

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -5,6 +5,7 @@ import * as miasma from "../systems/miasma/index.js";
 import * as beam from "../systems/beam/index.js";
 import { makePlayer, updatePlayer, drawPlayer } from "../entities/player.js";
 import { clear, drawGrid } from "../render/draw.js";
+import { streamAround } from "../world/chunks.js";
 
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById("game"));
@@ -56,6 +57,7 @@ function frame(now) {
 
   // UPDATE
   updatePlayer(player, dt);
+  streamAround(player.x, player.y);
   miasma.update(dt);
 
   // Lock camera to player (no lerp)

--- a/src/world/chunks.js
+++ b/src/world/chunks.js
@@ -1,0 +1,18 @@
+import { worldToTile, tileToChunk } from "../core/coords.js";
+import { emit } from "../core/events.js";
+import { TILE_SIZE, CHUNK_SIZE } from "./store.js";
+
+let current = null;
+
+export function streamAround(wx, wy) {
+  const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
+  const [cx, cy] = tileToChunk(tx, ty, CHUNK_SIZE);
+
+  if (!current || current.cx !== cx || current.cy !== cy) {
+    if (current) emit("onExitChunk", { cx: current.cx, cy: current.cy });
+    current = { cx, cy };
+    emit("onEnterChunk", current);
+  }
+
+  return current;
+}

--- a/src/world/store.js
+++ b/src/world/store.js
@@ -1,8 +1,8 @@
 // Minimal world stub to start; chunking scaffolding using shared helpers.
 import { worldToTile, tileToChunk, mod } from "../core/coords.js";
 
-const TILE_SIZE = 64; // world units per tile
-const CHUNK_SIZE = 16; // tiles per chunk
+export const TILE_SIZE = 64; // world units per tile
+export const CHUNK_SIZE = 16; // tiles per chunk
 
 export function getTile(wx, wy) {
   const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);


### PR DESCRIPTION
## Summary
- Introduce a lightweight pub/sub system with `on` and `emit`
- Track player chunk transitions and emit `onEnterChunk`/`onExitChunk` events
- Export shared chunk sizing constants for reuse

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a8d77c98832d84d5a438fdaa192a