### PR TITLE
feat: stream world chunks with deterministic generation

### DIFF
--- a/src/world/chunks.js
+++ b/src/world/chunks.js
@@ -1,18 +1,67 @@
 import { worldToTile, tileToChunk } from "../core/coords.js";
 import { emit } from "../core/events.js";
-import { TILE_SIZE, CHUNK_SIZE } from "./store.js";
+import { config } from "../core/config.js";
+import {
+  TILE_SIZE,
+  CHUNK_SIZE,
+  setChunk,
+  deleteChunk,
+  getChunk,
+} from "./store.js";
+import { generateChunk, evictChunk } from "./gen.js";
 
+const RADIUS = 2; // chunks in each direction from center
+
+const loaded = new Set();
+const pending = [];
 let current = null;
+
+function key(cx, cy) {
+  return `${cx},${cy}`;
+}
 
 export function streamAround(wx, wy) {
   const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
-  const [cx, cy] = tileToChunk(tx, ty, CHUNK_SIZE);
+  const [ccx, ccy] = tileToChunk(tx, ty, CHUNK_SIZE);
 
-  if (!current || current.cx !== cx || current.cy !== cy) {
+  const needed = new Set();
+  for (let dy = -RADIUS; dy <= RADIUS; dy++) {
+    for (let dx = -RADIUS; dx <= RADIUS; dx++) {
+      const k = key(ccx + dx, ccy + dy);
+      needed.add(k);
+      if (!loaded.has(k) && !pending.includes(k)) pending.push(k);
+    }
+  }
+
+  for (const k of Array.from(loaded)) {
+    if (!needed.has(k)) {
+      const [cx, cy] = k.split(",").map(Number);
+      const data = getChunk(cx, cy);
+      if (evictChunk) evictChunk(cx, cy, data);
+      deleteChunk(cx, cy);
+      loaded.delete(k);
+    }
+  }
+
+  let budget = config.maxChunkGenPerFrame;
+  while (budget > 0 && pending.length) {
+    const k = pending.shift();
+    const [cx, cy] = k.split(",").map(Number);
+    if (loaded.has(k)) continue;
+    const data = generateChunk(cx, cy);
+    setChunk(cx, cy, data);
+    loaded.add(k);
+    budget--;
+  }
+
+  if (!current || current.cx !== ccx || current.cy !== ccy) {
     if (current) emit("onExitChunk", { cx: current.cx, cy: current.cy });
-    current = { cx, cy };
+    current = { cx: ccx, cy: ccy };
     emit("onEnterChunk", current);
   }
 
-  return current;
+  return Array.from(loaded, (k) => {
+    const [cx, cy] = k.split(",").map(Number);
+    return { cx, cy };
+  });
 }

--- a/src/world/gen.js
+++ b/src/world/gen.js
@@ -1,0 +1,40 @@
+import { CHUNK_SIZE, TILE_SIZE } from "./store.js";
+import { chunkToWorld } from "../core/coords.js";
+import { config } from "../core/config.js";
+
+function mulberry32(a) {
+  return function () {
+    a |= 0;
+    a = (a + 0x6D2B79F5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function hash(cx, cy) {
+  let h = config.seed ^ (cx * 73856093) ^ (cy * 19349663);
+  return h >>> 0;
+}
+
+export function generateChunk(cx, cy) {
+  const rand = mulberry32(hash(cx, cy));
+  const tiles = new Array(CHUNK_SIZE * CHUNK_SIZE);
+  for (let i = 0; i < tiles.length; i++) tiles[i] = { id: 0, solid: false };
+
+  const entities = [];
+  if (rand() < 0.2) {
+    const [wx, wy] = chunkToWorld(cx, cy, CHUNK_SIZE, TILE_SIZE);
+    entities.push({
+      type: "rock",
+      wx: wx + rand() * CHUNK_SIZE * TILE_SIZE,
+      wy: wy + rand() * CHUNK_SIZE * TILE_SIZE,
+    });
+  }
+
+  return { tiles, entities };
+}
+
+export function evictChunk(_cx, _cy, _data) {
+  // placeholder for future resource cleanup
+}

--- a/src/world/store.js
+++ b/src/world/store.js
@@ -1,8 +1,29 @@
-// Minimal world stub to start; chunking scaffolding using shared helpers.
-import { worldToTile, tileToChunk, mod } from "../core/coords.js";
+import { worldToTile, tileToChunk, chunkToWorld, mod } from "../core/coords.js";
 
 export const TILE_SIZE = 64; // world units per tile
 export const CHUNK_SIZE = 16; // tiles per chunk
+
+const chunks = new Map(); // key `${cx},${cy}` → { tiles:[], entities:[] }
+
+function key(cx, cy) {
+  return `${cx},${cy}`;
+}
+
+export function setChunk(cx, cy, data) {
+  chunks.set(key(cx, cy), { cx, cy, ...data });
+}
+
+export function getChunk(cx, cy) {
+  return chunks.get(key(cx, cy));
+}
+
+export function deleteChunk(cx, cy) {
+  chunks.delete(key(cx, cy));
+}
+
+export function hasChunk(cx, cy) {
+  return chunks.has(key(cx, cy));
+}
 
 export function getTile(wx, wy) {
   const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
@@ -10,6 +31,33 @@ export function getTile(wx, wy) {
   const lx = mod(tx, CHUNK_SIZE);
   const ly = mod(ty, CHUNK_SIZE);
 
-  // Future: look up chunk (cx, cy) and tile (lx, ly); placeholder tile for now.
-  return { id: 0, solid: false };
+  const chunk = getChunk(cx, cy);
+  if (!chunk) return { id: 0, solid: false };
+  const tile = chunk.tiles[ly * CHUNK_SIZE + lx];
+  return tile ?? { id: 0, solid: false };
+}
+
+export function iterEntitiesInAABB(ax, ay, bx, by) {
+  const [tAx, tAy] = worldToTile(ax, ay, TILE_SIZE);
+  const [tBx, tBy] = worldToTile(bx, by, TILE_SIZE);
+  const [cAx, cAy] = tileToChunk(tAx, tAy, CHUNK_SIZE);
+  const [cBx, cBy] = tileToChunk(tBx, tBy, CHUNK_SIZE);
+
+  return (function* () {
+    for (let cy = cAy; cy <= cBy; cy++) {
+      for (let cx = cAx; cx <= cBx; cx++) {
+        const chunk = getChunk(cx, cy);
+        if (!chunk || !chunk.entities) continue;
+        for (const e of chunk.entities) {
+          if (e.wx >= ax && e.wx < bx && e.wy >= ay && e.wy < by) yield e;
+        }
+      }
+    }
+  })();
+}
+
+export function chunkBounds(cx, cy) {
+  const [wx, wy] = chunkToWorld(cx, cy, CHUNK_SIZE, TILE_SIZE);
+  const size = CHUNK_SIZE * TILE_SIZE;
+  return [wx, wy, wx + size, wy + size];
 }


### PR DESCRIPTION
## Summary
- Implement chunk streaming around the player with load/unload windows and generation budgets
- Track loaded chunk data and expose `iterEntitiesInAABB` for entity queries
- Add deterministic chunk generator seeded by coordinates

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4b09baab4832da536d305575c1ad3