### PR TITLE
Stream chunks and limit miasma work

### DIFF
--- a/src/core/config.js
+++ b/src/core/config.js
@@ -5,5 +5,6 @@ export const config = {
   maxDrawCalls: 2000,
   maxEdgeFillPerTick: 128,
   maxTilesUpdatedPerTick: 256,
+  maxDrawTilesPerFrame: 4096,
   player: { speed: 140 },
 };

--- a/src/core/game.js
+++ b/src/core/game.js
@@ -5,7 +5,7 @@ import * as miasma from "../systems/miasma/index.js";
 import * as beam from "../systems/beam/index.js";
 import { makePlayer, updatePlayer, drawPlayer } from "../entities/player.js";
 import { clear, drawGrid } from "../render/draw.js";
-import { streamAround } from "../world/chunks.js";
+import * as chunks from "../world/chunks.js";
 
 
 const canvas = /** @type {HTMLCanvasElement} */ (document.getElementById("game"));
@@ -57,8 +57,9 @@ function frame(now) {
 
   // UPDATE
   updatePlayer(player, dt);
-  streamAround(player.x, player.y);
-  miasma.update(dt);
+  chunks.streamAround(player.x, player.y);
+  const worldMotion = { x: 0, y: 0 };
+  miasma.update(dt, player.x, player.y, worldMotion);
 
   // Lock camera to player (no lerp)
   cam.x = player.x;


### PR DESCRIPTION
## Summary
- Stream nearby world chunks each frame
- Track player/world position in miasma updates and honor work budgets
- Cap miasma draw cost via maxDrawTilesPerFrame config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a4b3f8da54832db5a07c1ec8711f25