### PR TITLE
Anchor miasma fog to world coordinates

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -98,9 +98,10 @@ function frame(now) {
     y: windVel.vyTilesPerSec * tileSize * dt
   };
 
+  // External forces on the world (camera motion removed)
   const worldMotion = {
-    x: -camMotion.x + windMotion.x,
-    y: -camMotion.y + windMotion.y
+    x: windMotion.x,
+    y: windMotion.y
   };
 
   miasma.update(dt, cam.x, cam.y, worldMotion, w, h);


### PR DESCRIPTION
## Summary
- Ignore camera deltas when computing world motion; rely on wind drift only
- Track camera fractional tile offset and wind drift in miasma system
- Draw fog tiles using stored origin and offsets so they stay fixed in world space

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a600f581cc832dac6213f5152552d5