### PR TITLE
refactor rock tile storage for efficient drawing

### DIFF
--- a/src/systems/rocks/index.js
+++ b/src/systems/rocks/index.js
@@ -20,8 +20,27 @@ const CARVE_WALKERS   = 2;       // num of carve walkers
 const CARVE_STEPS     = 18;      // steps per carve walker
 
 
-// --- State: anchored rock tiles by key "tx,ty" ---
-const rockTiles = new Set();
+// --- State: anchored rock tiles stored by row ---
+// Map<ty, Set<tx>> for spatial lookups
+const rockTiles = new Map();
+
+function addRock(tx, ty) {
+  let row = rockTiles.get(ty);
+  if (!row) { row = new Set(); rockTiles.set(ty, row); }
+  row.add(tx);
+}
+
+function deleteRock(tx, ty) {
+  const row = rockTiles.get(ty);
+  if (!row) return;
+  row.delete(tx);
+  if (row.size === 0) rockTiles.delete(ty);
+}
+
+function hasRock(tx, ty) {
+  const row = rockTiles.get(ty);
+  return row ? row.has(tx) : false;
+}
 
 // Track generated chunks by key "cx,cy" to avoid duplicate work
 const generatedChunks = new Set();
@@ -53,7 +72,6 @@ function generateChunk(cx, cy, playerTx, playerTy) {
   const safeR2 = SPAWN_SAFE_TILES * SPAWN_SAFE_TILES;
 
   // local helpers
-  const keyOf = (x,y) => x + "," + y;
   const dirs4 = [[1,0],[-1,0],[0,1],[0,-1]];
   const dirs8 = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[-1,1],[1,-1],[-1,-1]];
   const inSafe = (tx,ty) => {
@@ -84,7 +102,7 @@ function generateChunk(cx, cy, playerTx, playerTy) {
     let tx = startTx, ty = startTy;
 
     for (let i = 0; i < steps; i++) {
-      if (!inSafe(tx,ty)) rockTiles.add(keyOf(tx,ty));
+      if (!inSafe(tx,ty)) addRock(tx,ty);
 
       // move: cardinal step with tiny diagonal wobble to reduce straight veins
       if (rng() < 0.85) {
@@ -120,15 +138,14 @@ function generateChunk(cx, cy, playerTx, playerTy) {
     // prune: remove degree<=1 to kill stringers
     const neighborCount = (x,y) => {
       let n = 0;
-      for (const [dx,dy] of dirs8) if (rockTiles.has(keyOf(x+dx,y+dy))) n++;
+      for (const [dx,dy] of dirs8) if (hasRock(x+dx,y+dy)) n++;
       return n;
     };
 
     for (let y = y0-1; y <= y1+1; y++) {
       for (let x = x0-1; x <= x1+1; x++) {
-        const k = keyOf(x,y);
-        if (!rockTiles.has(k)) continue;
-        if (neighborCount(x,y) <= 1 && rng() < PRUNE_TIPS_PROB) rockTiles.delete(k);
+        if (!hasRock(x,y)) continue;
+        if (neighborCount(x,y) <= 1 && rng() < PRUNE_TIPS_PROB) deleteRock(x,y);
       }
     }
 
@@ -139,7 +156,7 @@ function generateChunk(cx, cy, playerTx, playerTy) {
       let sx = x0 + (rng() * (x1 - x0 + 1) | 0);
       let sy = y0 + (rng() * (y1 - y0 + 1) | 0);
       for (let i = 0; i < CARVE_STEPS; i++) {
-        rockTiles.delete(keyOf(sx,sy));
+        deleteRock(sx,sy);
         const [dx,dy] = dirs8[(rng() * dirs8.length) | 0];
         sx += dx; sy += dy;
         if (sx < x0) sx = x0; if (sx > x1) sx = x1;
@@ -184,7 +201,7 @@ export function ensureRocksForView(playerX, playerY, radiusTiles=128) {
       const startTy = cy * CHUNK_SIZE;
       for (let ty = startTy; ty < startTy + CHUNK_SIZE; ty++) {
         for (let tx = startTx; tx < startTx + CHUNK_SIZE; tx++) {
-          rockTiles.delete(tx + "," + ty);
+          deleteRock(tx, ty);
         }
       }
     }
@@ -195,7 +212,7 @@ export function ensureRocksForView(playerX, playerY, radiusTiles=128) {
 // 1 if rock at world coord, else 0
 export function sample(wx, wy) {
   const [tx, ty] = worldToTile(wx, wy, TILE_SIZE);
-  return rockTiles.has(tx + "," + ty) ? 1 : 0;
+  return hasRock(tx, ty) ? 1 : 0;
 }
 
 // Draw rocks (centered on camera!)
@@ -206,15 +223,13 @@ export function draw(ctx, cam, viewW, viewH) {
   const ty1 = Math.floor((cam.y + viewH/2) / TILE_SIZE);
 
   ctx.fillStyle = "#555";
-  for (let ty = ty0; ty <= ty1; ty++) {
-    for (let tx = tx0; tx <= tx1; tx++) {
-      if (rockTiles.has(tx + "," + ty)) {
-        // <-- FIXED viewport math -->
-     const x = tx * TILE_SIZE - cam.x;
-const y = ty * TILE_SIZE - cam.y;
-ctx.fillRect(x, y, TILE_SIZE, TILE_SIZE);
-
-      }
+  for (const [ty, cols] of rockTiles) {
+    if (ty < ty0 || ty > ty1) continue;
+    for (const tx of cols) {
+      if (tx < tx0 || tx > tx1) continue;
+      const x = tx * TILE_SIZE - cam.x;
+      const y = ty * TILE_SIZE - cam.y;
+      ctx.fillRect(x, y, TILE_SIZE, TILE_SIZE);
     }
   }
 }
@@ -238,8 +253,7 @@ export function movePlayer(ent, dx, dy, radiusOverride) {
 
     for (let ty = minTy; ty <= maxTy; ty++) {
       for (let tx = minTx; tx <= maxTx; tx++) {
-        const k = tx + "," + ty;
-        if (!rockTiles.has(k)) continue;
+        if (!hasRock(tx, ty)) continue;
         const tileX = tx * TILE_SIZE;
         const tileY = ty * TILE_SIZE;
         const cx = clamp(targetX, tileX, tileX + TILE_SIZE);
@@ -268,8 +282,7 @@ export function movePlayer(ent, dx, dy, radiusOverride) {
 
     for (let ty = minTy; ty <= maxTy; ty++) {
       for (let tx = minTx; tx <= maxTx; tx++) {
-        const k = tx + "," + ty;
-        if (!rockTiles.has(k)) continue;
+        if (!hasRock(tx, ty)) continue;
         const tileX = tx * TILE_SIZE;
         const tileY = ty * TILE_SIZE;
         const cx = clamp(x, tileX, tileX + TILE_SIZE);
@@ -310,8 +323,7 @@ export function collidePlayer(player, radiusOverride) {
 
   for (let ty = minTy; ty <= maxTy; ty++) {
     for (let tx = minTx; tx <= maxTx; tx++) {
-      const k = tx + "," + ty;
-      if (!rockTiles.has(k)) continue;
+      if (!hasRock(tx, ty)) continue;
 
       // Tile center in world space
       const cx = tx * TILE_SIZE + half;


### PR DESCRIPTION
## Summary
- store rock tiles in a row map structure for spatial lookups
- draw only tiles within the camera bounds by iterating stored coordinates
- remove costly tile-grid scan from rendering

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7763f743c832db50bf80b1d73248c