### PR TITLE
Add enemy spawns to world generation

### DIFF
--- a/src/world/gen.js
+++ b/src/world/gen.js
@@ -1,6 +1,7 @@
 import { CHUNK_SIZE, TILE_SIZE } from "./store.js";
 import { chunkToWorld } from "../core/coords.js";
 import { config } from "../core/config.js";
+import { makeEnemy } from "../entities/enemy.js";
 
 function mulberry32(a) {
   return function () {
@@ -43,6 +44,22 @@ export function generateChunk(cx, cy) {
     const wx = baseWX + lx * TILE_SIZE + TILE_SIZE * 0.5;
     const wy = baseWY + ly * TILE_SIZE + TILE_SIZE * 0.5;
     entities.push({ type: "rock", wx, wy });
+  }
+
+  // Drop one or more enemies on non-solid tiles
+  const enemiesInChunk = 1 + Math.floor(rand() * 3);
+  for (let i = 0; i < enemiesInChunk; i++) {
+    let attempts = 0;
+    while (attempts++ < 10) {
+      const lx = Math.floor(rand() * CHUNK_SIZE);
+      const ly = Math.floor(rand() * CHUNK_SIZE);
+      const idx = ly * CHUNK_SIZE + lx;
+      if (tiles[idx].solid) continue;
+      const wx = baseWX + lx * TILE_SIZE + TILE_SIZE * 0.5;
+      const wy = baseWY + ly * TILE_SIZE + TILE_SIZE * 0.5;
+      entities.push(makeEnemy(wx, wy));
+      break;
+    }
   }
 
   return { tiles, entities };


### PR DESCRIPTION
## Summary
- import `makeEnemy` and spawn enemies on open tiles during chunk generation

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a79887e0e4832dae4fafcfcb8873d3