### PR TITLE
feat: add enemy movement and health

### DIFF
--- a/src/core/game.js
+++ b/src/core/game.js
@@ -174,13 +174,13 @@ function frame(now) {
     rocks.ensureRocksForView(player.x, player.y);
 
     // Update enemies
-const ax = cam.x - w / 2;
-const ay = cam.y - h / 2;
-const bx = cam.x + w / 2;
-const by = cam.y + h / 2;
-for (const e of iterEntitiesInAABB(ax, ay, bx, by)) {
-  if (e.type === "enemy") updateEnemy(e, dt);
-}
+    const ax = cam.x - w / 2;
+    const ay = cam.y - h / 2;
+    const bx = cam.x + w / 2;
+    const by = cam.y + h / 2;
+    for (const e of iterEntitiesInAABB(ax, ay, bx, by)) {
+      if (e.type === "enemy") updateEnemy(e, dt, player);
+    }
 
 
 


### PR DESCRIPTION
## Summary
- make enemies chase the player using new speed and velocity fields
- prevent enemies from walking through rocks via rock collision helper
- add basic health and removal logic for enemies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a799688f40832dad4cb4ab100b95ea