### PR TITLE
Fix laser beam damage using beam direction

### DIFF
--- a/src/systems/beam/index.js
+++ b/src/systems/beam/index.js
@@ -273,7 +273,7 @@ export function raycast(origin, dir, params = {}) {
       const tProj = vx * ux + vy * uy;         // distance along beam
       if (tProj < 0 || tProj > len) continue;  // outside segment
       // Perp distance to beam centerline — expand by enemy radius so it "feels" like the visual
-      const perp = Math.abs(vx * ny - vy * nx);
+      const perp = Math.abs(vx * uy - vy * ux);
       const er = (e.r ?? 0);
       if (perp <= rCore + er) {
         e.health -= LASER_DPS * dt;


### PR DESCRIPTION
## Summary
- use beam direction vector when calculating perpendicular distance for laser damage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7bb5f1ea8832da8c2f99c14974ebe