### PR TITLE
Add beam level scaling and HUD control

### DIFF
--- a/src/systems/beam/index.js
+++ b/src/systems/beam/index.js
@@ -24,18 +24,20 @@ const LEVEL_MIN = 1;
 const LEVEL_MAX = 16;
 const BASE = {
   bubbleMin: 32,
-  bubbleMax: 96,
+  bubbleMax: 64,    // smaller at level 1
   laserLen: 224,
   laserThick: 4,
-  coneLen: 128,
+  coneLen: 160,     // bigger at level 1
 };
 const MAX = {
   bubbleMin: 112,
-  bubbleMax: 336,
+  bubbleMax: 288,   // smaller at level 16
   laserLen: 784,
   laserThick: 14,
-  coneLen: 448,
+  coneLen: 480,     // bigger at level 16
 };
+
+
 const ANGLE_TOTAL_DEG = 64;
 const BUDGET_PER_STAMP = 160;
 


### PR DESCRIPTION
## Summary
- Add 16-level beam scaling with linear interpolation for size and length parameters
- Replace dev HUD beam sliders with a single Beam Level control with +/- buttons

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8c2dad154832d8fdec8025ea52f97